### PR TITLE
CPLSetErrorHandlerEx bug fixes

### DIFF
--- a/gdal/port/cpl_error.cpp
+++ b/gdal/port/cpl_error.cpp
@@ -1091,7 +1091,7 @@ CPLSetErrorHandlerEx( CPLErrorHandler pfnErrorHandlerNew, void* pUserData )
 
         pfnOldHandler = pfnErrorHandler;
 
-        if( pfnErrorHandler == nullptr )
+        if( pfnErrorHandlerNew == nullptr )
             pfnErrorHandler = CPLDefaultErrorHandler;
         else
             pfnErrorHandler = pfnErrorHandlerNew;


### PR DESCRIPTION
Once there has been the following call
```cpp
CPLSetErrorHandlerEx(NULL,NULL);
```
You can no longer set the error handling correctly,And the program segment error.
